### PR TITLE
fix: Use correct package name for Chinese on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo ./install.sh
 ### Manual Install  
 ```bash
 # Install dependencies (Fedora)
-sudo dnf install tesseract tesseract-langpack-eng tesseract-langpack-chi-sim python3-qt5 gnome-screenshot grim slurp
+sudo dnf install tesseract tesseract-langpack-eng tesseract-langpack-chi_sim python3-qt5 gnome-screenshot grim slurp
 
 # Install Python packages
 pip install PyQt5 pytesseract Pillow pyperclip

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ install_system_dependencies() {
     
     case $PKG_MANAGER in
         "dnf")
-            dnf install -y tesseract tesseract-langpack-eng tesseract-langpack-chi-sim \
+            dnf install -y tesseract tesseract-langpack-eng tesseract-langpack-chi_sim \
                           python3-qt5 python3-pip gnome-screenshot grim slurp \
                           python3-devel || true
             ;;

--- a/main.py
+++ b/main.py
@@ -240,7 +240,7 @@ def run_direct_ocr(language='eng'):
     except Exception as e:
         print(f"Tesseract not found: {e}")
         print("Please install tesseract-ocr:")
-        print("sudo dnf install tesseract tesseract-langpack-eng tesseract-langpack-chi-sim")
+        print("sudo dnf install tesseract tesseract-langpack-eng tesseract-langpack-chi_sim")
         sys.exit(1)
     
     # Create OCR instance and set language
@@ -279,7 +279,7 @@ def main():
     except Exception as e:
         print(f"Tesseract not found: {e}")
         print("Please install tesseract-ocr:")
-        print("sudo dnf install tesseract tesseract-langpack-eng tesseract-langpack-chi-sim")
+        print("sudo dnf install tesseract tesseract-langpack-eng tesseract-langpack-chi_sim")
         sys.exit(1)
     
     # Don't quit when last window is closed (for system tray apps)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -143,7 +143,7 @@ show_cleanup_info() {
     
     # Detect package manager and show appropriate commands
     if command -v dnf &> /dev/null; then
-        echo "    sudo dnf remove tesseract tesseract-langpack-eng tesseract-langpack-chi-sim"
+        echo "    sudo dnf remove tesseract tesseract-langpack-eng tesseract-langpack-chi_sim"
         echo "    sudo dnf remove python3-qt5 gnome-screenshot grim slurp"
     elif command -v apt &> /dev/null; then
         echo "    sudo apt remove tesseract-ocr tesseract-ocr-eng tesseract-ocr-chi-sim"


### PR DESCRIPTION
Tesseract's simplified Chinese package on Fedora is `chi_sim` not `chi-sim`